### PR TITLE
Change the amount type from DOUBLE to DECIMAL

### DIFF
--- a/models/staging/stg_payments.sql
+++ b/models/staging/stg_payments.sql
@@ -16,7 +16,7 @@ renamed as (
         payment_method,
 
         -- `amount` is currently stored in cents, so we convert it to dollars
-        amount / 100 as amount
+        (amount / 100)::DECIMAL(10,2) amount
 
     from source
 


### PR DESCRIPTION
**Overview**:
This PR changes the amount type from DOUBLE to DECIMAL(10,2). Because for currency column, it make more sense to use the DECIMAL type instead of DOUBLE type.

**Changes**:
- CAST the type to DECIMAL

**Rationale**:
To better understand and mitigate any potential distortions caused by data rounding.

UPDATED (2025/03/07): 
Please see the comment below